### PR TITLE
ci: Remove installation of dependencies pre publish

### DIFF
--- a/.github/workflows/publish_ground_control_client.yml
+++ b/.github/workflows/publish_ground_control_client.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
-      - name: Install dependencies
-        run: dart pub get
-        working-directory: ground_control_client
       - name: Publish
         run: dart pub publish --force --skip-validation
         working-directory: ground_control_client

--- a/.github/workflows/publish_serverpod_cloud_cli.yml
+++ b/.github/workflows/publish_serverpod_cloud_cli.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
-      - name: Install dependencies
-        run: dart pub get
-        working-directory: serverpod_cloud_cli
       - name: Publish
         run: dart pub publish --force --skip-validation
         working-directory: serverpod_cloud_cli


### PR DESCRIPTION
# Changes

Removes the installation of dependencies before the publish step. The reason for this is that it is not needed and this step will fail for the CLI as it may depend on a client version that is not yet published.